### PR TITLE
Fix reading json from client (ignore mimetype).

### DIFF
--- a/heutagogy/views.py
+++ b/heutagogy/views.py
@@ -14,7 +14,7 @@ def index():
 
 @app.route('/api/v1/bookmarks', methods=['POST'])
 def bookmarks_post():
-    r = request.get_json()
+    r = request.get_json(force=True)
 
     bookmark = dict()
     try:


### PR DESCRIPTION
If client sends a request with json, but without adding “content type is json” header, `get_json` function returns nothing. By adding `force=true` param `get_json` function ignores mimetype and returns a parsed json object.