### PR TITLE
Fix losing timezone info

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -22,4 +22,7 @@ in python.mkDerivation {
 
     flake8 .
   '';
+
+  # This sets FLASK_APP environment variable, so you don't have to.
+  FLASK_APP = "heutagogy";
 }

--- a/heutagogy/persistence.py
+++ b/heutagogy/persistence.py
@@ -1,8 +1,23 @@
 from heutagogy import app
 from flask_sqlalchemy import SQLAlchemy
 import datetime
+import pytz
 
 db = SQLAlchemy(app)
+
+
+# SQLite doesn't store timezones, so we convert all timestamps to UTC
+# to not save incorrect info.
+def to_utc(t):
+    """Convert datetime to UTC."""
+    if t is None:
+        return t
+
+    if t.tzinfo is None or t.tzinfo.utcoffset(t) is None:
+        # t is naive datetime (not aware of timezone)
+        return t.replace(tzinfo=pytz.utc)
+
+    return t.astimezone(pytz.utc)
 
 
 class Bookmark(db.Model):
@@ -22,8 +37,8 @@ class Bookmark(db.Model):
         self.user = user
         self.url = url
         self.title = title
-        self.timestamp = timestamp
-        self.read = read
+        self.timestamp = to_utc(timestamp)
+        self.read = to_utc(read)
 
     def __repr__(self):
         return '<Bookmark %r of %r>' % self.url % self.user

--- a/tests.py
+++ b/tests.py
@@ -419,6 +419,17 @@ class HeutagogyTestCase(unittest.TestCase):
         self.assertEqual({'error': 'Updating id is not allowed'},
                          get_json(res))
 
+    @single_user
+    def test_handle_timezone(self):
+        res = self.app.post(
+            'api/v1/bookmarks',
+            content_type='application/json',
+            data=json.dumps({'url': 'https://github.com/',
+                             'timestamp': '2017-01-01T01:20:13+0200'}),
+            headers=[self.user1])
+        self.assertEqual(HTTPStatus.CREATED, res.status_code)
+        self.assertEqual('2016-12-31T23:20:13', get_json(res)['timestamp'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
SQLite does not have proper support for datetime type and is unable to
store timezone. So we translate all timestamps to UTC.