### PR TITLE
bookmark.user: string -> integer

### DIFF
--- a/heutagogy/__init__.py
+++ b/heutagogy/__init__.py
@@ -2,7 +2,7 @@ from flask import Flask
 
 app = Flask(__name__)
 
-import heutagogy.heutagogy   # noqa
-import heutagogy.persistence # noqa
-import heutagogy.views       # noqa
-import heutagogy.auth        # noqa
+from heutagogy.heutagogy import db # noqa
+import heutagogy.persistence       # noqa
+import heutagogy.views             # noqa
+import heutagogy.auth              # noqa

--- a/heutagogy/heutagogy.py
+++ b/heutagogy/heutagogy.py
@@ -2,6 +2,8 @@ from heutagogy import app
 import os
 from datetime import timedelta
 from flask_mail import Mail
+from flask_migrate import Migrate
+from flask_sqlalchemy import SQLAlchemy
 
 app.config.from_object(__name__)
 app.config.update(dict(
@@ -31,3 +33,6 @@ if not app.config['SECRET_KEY']:
 
 if app.config['USER_ENABLE_EMAIL']:
     mail = Mail(app)
+
+db = SQLAlchemy(app)
+migrate = Migrate(app, db)

--- a/heutagogy/persistence.py
+++ b/heutagogy/persistence.py
@@ -1,11 +1,7 @@
-from heutagogy import app
-from flask_sqlalchemy import SQLAlchemy
-from flask_migrate import Migrate
+from heutagogy import db
+from heutagogy.auth import User
 import datetime
 import pytz
-
-db = SQLAlchemy(app)
-migrate = Migrate(app, db)
 
 
 # SQLite doesn't store timezones, so we convert all timestamps to UTC
@@ -24,7 +20,7 @@ def to_utc(t):
 
 class Bookmark(db.Model):
     id = db.Column(db.Integer, primary_key=True)
-    user = db.Column(db.String, nullable=False)
+    user = db.Column(db.Integer, db.ForeignKey(User.id), nullable=False)
     timestamp = db.Column(db.DateTime, nullable=False)
     url = db.Column(db.String, nullable=False)
     title = db.Column(db.String, nullable=False)

--- a/migrations/versions/797321279ea1_.py
+++ b/migrations/versions/797321279ea1_.py
@@ -1,0 +1,27 @@
+"""bookmark.user: string -> integer
+
+Revision ID: 797321279ea1
+Revises: 2f8813af460d
+Create Date: 2017-01-23 01:23:04.078995
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '797321279ea1'
+down_revision = '2f8813af460d'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('bookmark', 'user', type_=sa.Integer(), existing_nullable=False,
+            postgresql_using='bookmark.user::integer')
+    op.create_foreign_key('bookmark_user_fkey', 'bookmark', 'user', ['user'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint('bookmark_user_fkey', 'bookmark', type_='foreignkey')
+    op.alter_column('bookmark', 'user', type_=sa.String(), existing_nullable=False)


### PR DESCRIPTION
This is needed because postgres can't automatically convert string to
integer and retrieving bookmarks fails with the following error.

```
sqlalchemy.exc.ProgrammingError: (psycopg2.ProgrammingError) operator does not exist: character varying = integer
LINE 3: WHERE bookmark."user" = 1
                              ^
HINT:  No operator matches the given name and argument type(s). You might need to add explicit type casts.
 [SQL: 'SELECT bookmark.id AS bookmark_id, bookmark."user" AS bookmark_user, bookmark.timestamp AS bookmark_timestamp, bookmark.url AS bookmark_url, bookmark.title AS bookmark_title, bookmark.read AS bookmark_read \nFROM bookmark \nWHERE bookmark."user" = %(user_1)s \n LIMIT %(param_1)s OFFSET %(param_2)s'] [parameters: {'param_2': 0, 'param_1': 20, 'user_1': 1}]
```