### PR TITLE
Drop sqlite support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,20 @@
 language: python
 python:
   - "3.5"
+services:
+  - postgresql
+env:
+  - DATABASE_URL=postgres://postgres@localhost/heutagogy
+
 install:
   - pip install flake8
   - pip install -r requirements.txt
 script:
   - flake8 . --exclude=migrations
   - ./tests.py
+
+before_script:
+  - psql -c 'create database heutagogy;' -U postgres
 
 notifications:
   webhooks:

--- a/heutagogy/persistence.py
+++ b/heutagogy/persistence.py
@@ -4,8 +4,8 @@ import datetime
 import pytz
 
 
-# SQLite doesn't store timezones, so we convert all timestamps to UTC
-# to not save incorrect info.
+# The database doesn't store timezones, so we convert all timestamps
+# to UTC to not save incorrect info.
 def to_utc(t):
     """Convert datetime to UTC."""
     if t is None:
@@ -13,9 +13,9 @@ def to_utc(t):
 
     if t.tzinfo is None or t.tzinfo.utcoffset(t) is None:
         # t is naive datetime (not aware of timezone)
-        return t.replace(tzinfo=pytz.utc)
+        return t
 
-    return t.astimezone(pytz.utc)
+    return t.astimezone(pytz.utc).replace(tzinfo=None)
 
 
 class Bookmark(db.Model):

--- a/tests.py
+++ b/tests.py
@@ -55,7 +55,6 @@ class HeutagogyTestCase(unittest.TestCase):
         return ('Authorization', 'JWT ' + token) if token else None
 
     def setUp(self):
-        heutagogy.app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
         heutagogy.app.config['TESTING'] = True
 
         db.create_all()
@@ -524,9 +523,6 @@ class HeutagogyTestCase(unittest.TestCase):
         self.assertEqual(HTTPStatus.NO_CONTENT, res.status_code)
         self.assertEqual(b'', res.get_data())
 
-    # IDs are reused after deleting a bookmark
-    # https://github.com/heutagogy/heutagogy-backend/issues/70
-    @unittest.expectedFailure
     @single_user
     def test_delete_does_not_reuse_ids(self):
         res = self.add_bookmark()


### PR DESCRIPTION
Problem: sqlite does not support many feature normal databases do. It
is hard to write migrations for sqlite and it does not support NULLS
FIRST in the ORDER BY, which is needed for deterministic ordering of
bookmarks.

Solution: I drop sqlite support from now on and adapt tests to use
postgres database.