### PR TITLE
Deterministic ordering for GET /bookmarks

### DIFF
--- a/heutagogy/views.py
+++ b/heutagogy/views.py
@@ -30,13 +30,15 @@ class Bookmarks(Resource):
     @token_required
     def get(self):
         url = request.args.get('url')
-        if url is None:
-            result = db.Bookmark.query.filter_by(user=current_user.id) \
-                                      .paginate().items
-        else:
-            result = db.Bookmark.query.filter_by(user=current_user.id,
-                                                 url=urldefrag(url).url) \
-                                      .paginate().items
+
+        filters = dict(user=current_user.id)
+        if url is not None:
+            filters['url'] = urldefrag(url).url
+        result = db.Bookmark.query.filter_by(**filters) \
+                                  .order_by(
+                                      db.Bookmark.read.desc().nullsfirst(),
+                                      db.Bookmark.timestamp.desc()) \
+                                  .paginate().items
         return list(map(lambda x: x.to_dict(), result))
 
     @token_required

--- a/tests.py
+++ b/tests.py
@@ -592,6 +592,36 @@ class HeutagogyTestCase(unittest.TestCase):
         self.assertEqual('https://medium.com/some-article',
                          get_json(res)['url'])
 
+    @single_user
+    def test_bookmarks_order(self):
+        id1 = get_json(self.add_bookmark({
+            'url': 'http://example3.com',
+            'timestamp': '2017-02-01T11:12:12Z',
+        }))['id']
+        id2 = get_json(self.add_bookmark({
+            'url': 'http://example2.com',
+            'timestamp': '2017-02-01T12:30:05Z',
+            'read': '2017-02-01T13:20:01Z',
+        }))['id']
+        id3 = get_json(self.add_bookmark({
+            'url': 'http://example1.com',
+            'timestamp': '2017-02-01T12:30:05Z',
+        }))['id']
+        id4 = get_json(self.add_bookmark({
+            'url': 'http://example4.com',
+            'timestamp': '2017-01-01T12:11:13Z',
+            'read': '2017-02-01T13:20:02Z',
+        }))['id']
+
+        # should be [3, 1, 4, 2]
+        b = get_json(self.app.get('/api/v1/bookmarks',
+                                  headers=[self.user1]))
+
+        self.assertEqual(id3, b[0]['id'])
+        self.assertEqual(id1, b[1]['id'])
+        self.assertEqual(id4, b[2]['id'])
+        self.assertEqual(id2, b[3]['id'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit adds deterministic ordering to the GET /bookmarks
call. The ordering algorithm is the same as is used in current
frontend implementation.

See #77 for full issue description.