### PR TITLE
Include Link into Access-Control-Expose-Headers

### DIFF
--- a/heutagogy/views.py
+++ b/heutagogy/views.py
@@ -19,6 +19,7 @@ api = Api(app)
 @app.after_request
 def after_request(response):
     response.headers.add('Access-Control-Allow-Origin', '*')
+    response.headers['Access-Control-Expose-Headers'] = 'Link'
     if request.method == 'OPTIONS':
         response.headers['Access-Control-Allow-Methods'] = \
             'DELETE, GET, POST, PUT'


### PR DESCRIPTION
Problem: the frontend could not read Link header as it is not allowed
to read headers in cross-origin request, unless explicitly allowed.

Solution: add Acess-Control-Expose-Headers header which allows
exposing Link header to the client.