### PR TITLE
Revert "Add ACME response"

### DIFF
--- a/heutagogy/__init__.py
+++ b/heutagogy/__init__.py
@@ -6,4 +6,3 @@ from heutagogy.heutagogy import db # noqa
 import heutagogy.persistence       # noqa
 import heutagogy.views             # noqa
 import heutagogy.auth              # noqa
-import heutagogy.acme              # noqa

--- a/heutagogy/acme.py
+++ b/heutagogy/acme.py
@@ -1,6 +1,0 @@
-from heutagogy import app
-
-if app.config['ACME_CHALLENGE']:
-    @app.route('/.well-known/acme-challenge/' + app.config['ACME_CHALLENGE'])
-    def get_acme():
-        return app.config['ACME_RESPONSE']

--- a/heutagogy/heutagogy.py
+++ b/heutagogy/heutagogy.py
@@ -22,9 +22,6 @@ app.config.update(dict(
     MAIL_PORT=int(os.getenv('MAIL_PORT', '465')),
     MAIL_USE_SSL=int(os.getenv('MAIL_USE_SSL', True)),
 
-    ACME_CHALLENGE=os.getenv('ACME_CHALLENGE'),
-    ACME_RESPONSE=os.getenv('ACME_RESPONSE'),
-
     USER_APP_NAME='Heutagogy',
     SQLALCHEMY_DATABASE_URI=os.getenv(
         'DATABASE_URL', 'postgresql:///heutagogy'),


### PR DESCRIPTION
Reverts heutagogy/heutagogy-backend#87

It turned out to be not needed, as ACME provides DNS challenge that is much easier.