### PR TITLE
Reset version to 0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='Heutagogy',
-    version='1.0',
+    version='0.1',
     url='https://github.com/heutagogy/heutagogy-backend',
     packages=['heutagogy'],
     license='AGPL3',


### PR DESCRIPTION
Problem: we don't have enough functionality to claim we're 1.0. Also,
other Heutagogy components use much lower versions.