### PR TITLE
Return lost bookmarks on dev server

### DIFF
--- a/heutagogy/views.py
+++ b/heutagogy/views.py
@@ -55,7 +55,11 @@ class Bookmarks(Resource):
         filters = [db.Bookmark.user == current_user.id]
         if url is not None:
             filters.append(db.Bookmark.url == urldefrag(url).url)
-        filters.append(db.Bookmark.tags.contains(tags))
+
+        # If Bookmark.url is null, filtering will yield no results
+        if tags:
+            filters.append(db.Bookmark.tags.contains(tags))
+
         result = db.Bookmark.query.filter(*filters) \
                                   .order_by(
                                       db.Bookmark.read.desc().nullsfirst(),


### PR DESCRIPTION
From database console, all bookmarks are still there, but are not
shown in the application. The most likely cause is
`db.Bookmark.tags.contains` filter.

(I believe `NULL contains [] == false`.)

Solution: only add filter if there are tags to search for.

/cc @drets 