### PR TITLE
Allow updating bookmark tags

### DIFF
--- a/heutagogy/views.py
+++ b/heutagogy/views.py
@@ -161,6 +161,8 @@ class Bookmark(Resource):
                 bookmark.read = aniso8601.parse_datetime(update['read'])
             else:
                 bookmark.read = None
+        if 'tags' in update:
+            bookmark.tags = update['tags']
 
         db.db.session.add(bookmark)
         db.db.session.commit()

--- a/tests.py
+++ b/tests.py
@@ -755,6 +755,28 @@ class HeutagogyTestCase(unittest.TestCase):
         self.assertEqual(HTTPStatus.OK, res.status_code)
         self.assertEqual([dict(bookmark, id=1, read=None)], get_json(res))
 
+    @single_user
+    def test_update_bookmark_tags(self):
+        bookmark = {
+            'url': 'http://github.com',
+            'title': 'test title',
+            'tags': ['github', 'test'],
+        }
+        res = self.add_bookmark(bookmark)
+        self.assertEqual(HTTPStatus.CREATED, res.status_code)
+        result = get_json(res)
+        bookmark_id = result['id']
+
+        res = self.app.post(
+            '/api/v1/bookmarks/{}'.format(bookmark_id),
+            content_type='application/json',
+            data=json.dumps({'tags': ['test']}),
+            headers=[self.user1])
+
+        self.assertEqual(HTTPStatus.OK, res.status_code)
+        result = get_json(res)
+        self.assertEqual(['test'], result['tags'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Currently, the server does not allow to update bookmark's tags.

Add handling so it is possible now.