### PR TITLE
Return list of user tags

### DIFF
--- a/heutagogy/views.py
+++ b/heutagogy/views.py
@@ -195,6 +195,16 @@ class BookmarkContent(Resource):
         return {'html': bookmark.content_html, 'text': bookmark.content_text}
 
 
+class Tags(Resource):
+    @token_required
+    def get(self):
+        bookmarks = db.Bookmark.query \
+                    .filter(db.Bookmark.user == current_user.id,
+                            db.Bookmark.tags != None).all() # noqa
+        return list(set().union(*map(lambda x: x.tags, bookmarks)))
+
+
 api.add_resource(Bookmarks,       '/api/v1/bookmarks')
 api.add_resource(Bookmark,        '/api/v1/bookmarks/<int:id>')
 api.add_resource(BookmarkContent, '/api/v1/bookmarks/<int:id>/content')
+api.add_resource(Tags,            '/api/v1/tags')

--- a/tests.py
+++ b/tests.py
@@ -777,6 +777,45 @@ class HeutagogyTestCase(unittest.TestCase):
         result = get_json(res)
         self.assertEqual(['test'], result['tags'])
 
+    @single_user
+    def test_get_tags(self):
+        res = self.add_bookmark({
+            'url': 'http://github.com',
+            'title': 'test title',
+            'tags': ['github', 'test'],
+        })
+        self.assertEqual(HTTPStatus.CREATED, res.status_code)
+        res = self.add_bookmark({
+            'url': 'http://github.com',
+            'title': 'test title',
+            'tags': ['blah', 'test'],
+        })
+        self.assertEqual(HTTPStatus.CREATED, res.status_code)
+        res = self.add_bookmark({
+            'url': 'http://github.com',
+            'title': 'test title',
+            'tags': ['hello', 'world'],
+        })
+        self.assertEqual(HTTPStatus.CREATED, res.status_code)
+
+        res = self.app.get(
+            '/api/v1/tags',
+            headers=[self.user1])
+
+        self.assertEqual(HTTPStatus.OK, res.status_code)
+        self.assertEqual(sorted(['github', 'test', 'blah', 'hello', 'world']),
+                         sorted(get_json(res)))
+
+    @single_user
+    def test_get_tags_empty(self):
+        res = self.app.get(
+            '/api/v1/tags',
+            headers=[self.user1])
+
+        self.assertEqual(HTTPStatus.OK, res.status_code)
+        self.assertEqual(sorted([]),
+                         sorted(get_json(res)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add /tags endpoint that returns a list of all tags created by user.
It can be used by client to provide better autocompletion.

Note that current implementation is slow and should be improved
later.