### PR TITLE
Fix title detection on some sites

### DIFF
--- a/heutagogy/views.py
+++ b/heutagogy/views.py
@@ -126,7 +126,7 @@ class Bookmarks(Resource):
             if entity.get('title'):
                 title = entity.get('title')
             else:
-                title = entity.get('url')
+                title = url
 
             tags = entity.get('tags')
 


### PR DESCRIPTION
The background job expects title to be equal to url to mean the title
is not set. This is not true for bookmarks that have anchors or utm_
options as these are filtered out.

Make title equal to _filtered_ url initially, so title detections
works as expected.

Fixes #92.