### PR TITLE
Fix heroku warning

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.5.2
+python-3.6.4


### PR DESCRIPTION
During deployment, heroku emits the following warning:

```
-----> Python app detected

 !     The latest version of Python 3 is python-3.6.4 (you are using python-3.5.2, which is unsupported).

 !     We recommend upgrading by specifying the latest version (python-3.6.4).

       Learn More: https://devcenter.heroku.com/articles/python-runtimes
```

Update runtime version.